### PR TITLE
Detect Edge UA for Chromium-based versions properly

### DIFF
--- a/lib/user_agent/browsers/edge.rb
+++ b/lib/user_agent/browsers/edge.rb
@@ -4,7 +4,7 @@ class UserAgent
       OS_REGEXP = /Windows NT [\d\.]+|Windows Phone (OS )?[\d\.]+/
 
       def self.extend?(agent)
-        agent.last && agent.last.product == "Edge"
+        agent.last && agent.last.product =~ /Edge?/
       end
 
       def browser

--- a/spec/browsers/edge_user_agent_spec.rb
+++ b/spec/browsers/edge_user_agent_spec.rb
@@ -41,3 +41,51 @@ describe "Mozilla/5.0 SHC; SHC-Unit-04973; SHC-HTS; SHC-KIOSK; SHC-MAC-0000 (Win
     expect(@useragent.os).to eq("Windows 10")
   end
 end
+
+describe "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Safari/537.36 Edg/81.0.100.0" do
+  before do
+    @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Safari/537.36 Edg/81.0.100.0")
+  end
+
+  it_should_behave_like "Edge browser"
+
+  it "should return '81.0.100.0' as its version" do
+    expect(@useragent.version).to eq("81.0.100.0")
+  end
+
+  it "should return 'Windows 10' as its os" do
+    expect(@useragent.os).to eq("Windows 10")
+  end
+end
+
+describe "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.74 Safari/537.36 Edg/79.0.309.43" do
+  before do
+    @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.74 Safari/537.36 Edg/79.0.309.43")
+  end
+
+  it_should_behave_like "Edge browser"
+
+  it "should return '79.0.309.43' as its version" do
+    expect(@useragent.version).to eq("79.0.309.43")
+  end
+
+  it "should return 'Windows 10' as its os" do
+    expect(@useragent.os).to eq("Windows 10")
+  end
+end
+
+describe "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Safari/537.36 Edg/81.0.416.77,gzip(gfe)" do
+  before do
+    @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Safari/537.36 Edg/81.0.416.77,gzip(gfe)")
+  end
+
+  it_should_behave_like "Edge browser"
+
+  it "should return '81.0.416.77' as its version" do
+    expect(@useragent.version).to eq("81.0.416.77")
+  end
+
+  it "should return 'Windows 10' as its os" do
+    expect(@useragent.os).to eq("Windows 10")
+  end
+end


### PR DESCRIPTION
This was outdated and the new format for Chromium-based Edge wasn't supported.

