### PR TITLE
Update Edge browser detection

### DIFF
--- a/lib/user_agent/browsers/edge.rb
+++ b/lib/user_agent/browsers/edge.rb
@@ -4,7 +4,7 @@ class UserAgent
       OS_REGEXP = /Windows NT [\d\.]+|Windows Phone (OS )?[\d\.]+/
 
       def self.extend?(agent)
-        agent.last && agent.last.product =~ /Edge?/
+        agent.last && %w(Edge Edg EdgA EdgiOS).include?(agent.last.product)
       end
 
       def browser

--- a/spec/browsers/chrome_user_agent_spec.rb
+++ b/spec/browsers/chrome_user_agent_spec.rb
@@ -354,3 +354,27 @@ describe "UserAgent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, 
     expect(@useragent.os).to eq("Linux x86_64")
   end
 end
+
+describe "Mozilla/5.0 (Linux; Android 12; SM-G998U Build/SP1A.210812.016; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/97.0.4692.98 Mobile Safari/537.36 EdgW/1.0" do
+  before do
+    @useragent = UserAgent.parse("Mozilla/5.0 (Linux; Android 12; SM-G998U Build/SP1A.210812.016; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/97.0.4692.98 Mobile Safari/537.36 EdgW/1.0")
+  end
+
+  it_should_behave_like "Chrome browser"
+
+  it "should return '537.36' as its build" do
+    expect(@useragent.build).to eq("537.36")
+  end
+
+  it "should return '97.0.4692.98' as its version" do
+    expect(@useragent.version).to eq("97.0.4692.98")
+  end
+
+  it "should return '537.36' as its webkit version" do
+    expect(@useragent.webkit.version).to eq("537.36")
+  end
+
+  it "should return 'Android' as its platform" do
+    expect(@useragent.platform).to eq("Android")
+  end
+end


### PR DESCRIPTION
This is a fix for https://3.basecamp.com/2914079/buckets/27/todos/4560109938

The customer is running an Android device with the user agent:

```
Mozilla/5.0 (Linux; Android 12; SM-G998U Build/SP1A.210812.016; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/97.0.4692.98 Mobile Safari/537.36 EdgW/1.0
```

The last part, `EdgW/1.0`, was confusing our regexp, and it reported the browser as Edge v1.0.

`EdgW/1.0` might mean that it's actually an Edge webview, but that's [uncertain](https://stackoverflow.com/questions/68208057/what-does-edgew-mean-in-the-microsoft-edge-useragent). The [identifier should be EdgA according to Microsoft](https://docs.microsoft.com/en-us/microsoft-edge/web-platform/user-agent-guidance#identifiers-for-microsoft-edge-on-various-platforms).

Whether it's an Edge webview or not, for compatibility reasons it's better to report the browser as Chrome.

//cc @basecamp/sip 