### PR TITLE
Detect HeadlessChrome as a chrome browser

### DIFF
--- a/lib/user_agent/browsers/chrome.rb
+++ b/lib/user_agent/browsers/chrome.rb
@@ -3,7 +3,7 @@ class UserAgent
     class Chrome < Base
       def self.extend?(agent)
         agent.detect { |useragent|
-          %w(Chrome CriOS).include?(useragent.product)
+          %w(Chrome HeadlessChrome CriOS).include?(useragent.product)
         }
       end
 
@@ -23,6 +23,8 @@ class UserAgent
       def version
         str = if detect_product("CriOs")
           crios.version
+        elsif detect_product("HeadlessChrome")
+          headlesschrome.version
         else
           chrome.version
         end

--- a/spec/browsers/chrome_user_agent_spec.rb
+++ b/spec/browsers/chrome_user_agent_spec.rb
@@ -140,6 +140,34 @@ describe "UserAgent: 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/535.19 (KH
   end
 end
 
+describe "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/106.0.5249.103 Safari/537.36" do
+  before do
+    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/106.0.5249.103 Safari/537.36")
+  end
+
+  it_should_behave_like "Chrome browser"
+
+  it "should return '537.36' as its build" do
+    expect(@useragent.build).to eq("537.36")
+  end
+
+  it "should return '106.0.5249.103' as its version" do
+    expect(@useragent.version).to eq("106.0.5249.103")
+  end
+
+  it "should return '537.36' as its webkit version" do
+    expect(@useragent.webkit.version).to eq("537.36")
+  end
+
+  it "should return 'Macintosh' as its platform" do
+    expect(@useragent.platform).to eq("Macintosh")
+  end
+
+  it "should return 'OS X 10.15.7' as its os" do
+    expect(@useragent.os).to eq("OS X 10.15.7")
+  end
+end
+
 describe "Mozilla/5.0 (Linux; Android 4.2; Nexus 7 Build/JOP40C) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19" do
   before do
     @useragent = UserAgent.parse("Mozilla/5.0 (Linux; Android 4.2; Nexus 7 Build/JOP40C) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19")


### PR DESCRIPTION
I noticed running system tests locally that they were failing with this message:

> Incompatible browser: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/106.0.5249.103 Safari/537.36

This is because the headless chrome instance was using `HeadlessChrome` as its product string, instead of just `Chrome`.

//cc @basecamp/sip 